### PR TITLE
a few fixes after testing in different conditions and with az version…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For more details and some background information about this project, see the blo
 * Install the [azure-cli](https://github.com/Azure/azure-cli) and make sure the `az` binary can be found from $PATH
 * Login with `az login`
 * Create a resource group for the resources the scripts create with `az group create --name Travis --location "West Europe"`
+* remove default location you may have configured with `az configure --defaults location=''`
 
 ## Set required environment variables
 


### PR DESCRIPTION
… 2.0.23

When you have az configure having a default location where container instances are not available, the run.sh fails. 

Also tried to fix a few things on metrics. 

It works at least by issuing the recommended command from the script. It does not always work when executing during the script execution itself (race conditions). Still, `PT1M` seems unavailable in my case, while `P1D` is. `az monitor` parameter names seem to be have changed also. 